### PR TITLE
Fix D-Bus crash by using correct object path for org.freedesktop.DBus

### DIFF
--- a/Source/DKProxy.m
+++ b/Source/DKProxy.m
@@ -1111,7 +1111,7 @@ NSString* DKBusReconnectedNotification = @"DKBusReconnectedNotification";
       DKEndpoint *ep = [[DKEndpointManager sharedEndpointManager] endpointForWellKnownBus: DBUS_BUS_SYSTEM];
       systemBus = [[DKDBus alloc] initWithEndpoint: ep
                                         andService: @"org.freedesktop.DBus"
-                                           andPath: @"/"];
+                                           andPath: @"/org/freedesktop/DBus"];
     }
     [busLock unlock];
   }


### PR DESCRIPTION
* This is necessary for newer systems like Arch Linux not to crash with AddMatch errors.
* Confirmed this still works on Debian 12.